### PR TITLE
changed the lines 154 and 170

### DIFF
--- a/vignettes/Lab4_Distributions_II.Rmd
+++ b/vignettes/Lab4_Distributions_II.Rmd
@@ -151,7 +151,7 @@ for(i in 2:length(flips)){
   sequence[i-1] <- paste0(first_element,second_element)
 }
 
-table(sequence)/10000
+table(sequence)/sum(table(sequence))
 
 ## 3 element sequences
 
@@ -167,7 +167,7 @@ for(i in 3:length(flips)){
                           third_element)
 }
 
-table(sequence)/10000
+table(sequence)/sum(table(sequence))
 
 ```
 


### PR DESCRIPTION
The total number of combinations for two flips (lines 145-152) and for three flips (lines 157-168) differ from the total number of sampled coin flips (i.e., 10000).  To get the proportions of combinations, we should divide combinations in the sequence by the total number of sequence (i.e., sum(table(sequences)).  By dividing the numbers of combinations by the total number of combinations, proportions add up to 1.00